### PR TITLE
Update link to SKILL.md in API reference

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Playwright Skill - Complete API Reference
 
-This document contains the comprehensive Playwright API reference and advanced patterns. For quick-start execution patterns, see [SKILL.md](SKILL.md).
+This document contains the comprehensive Playwright API reference and advanced patterns. For quick-start execution patterns, see [SKILL.md](skills/playwright-skill/SKILL.md).
 
 ## Table of Contents
 


### PR DESCRIPTION
This is only a reference fix to put the correct link in the doc inside github. 

Unless this .md doc was meant to be used differently, but currently when reading on Github, we don't navigate to the right file. 