### PR TITLE
docs: relocate API reference and align with Agent Skills spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **General-purpose browser automation as a Claude Skill**
 
-A [Claude Skill](https://www.anthropic.com/news/skills) that enables Claude to write and execute any Playwright automation on-the-fly - from simple page tests to complex multi-step flows. Packaged as a [Claude Code Plugin](https://docs.claude.com/en/docs/claude-code/plugins) for easy installation and distribution.
+A [Claude Skill](https://www.anthropic.com/blog/skills) that enables Claude to write and execute any Playwright automation on-the-fly - from simple page tests to complex multi-step flows. Packaged as a [Claude Code Plugin](https://docs.claude.com/en/docs/claude-code/plugins) for easy installation and distribution.
 
 Claude autonomously decides when to use this skill based on your browser automation needs, loading only the minimal information required for your specific task.
 
@@ -24,6 +24,7 @@ This repository is structured as a [Claude Code Plugin](https://docs.claude.com/
 ### Understanding the Structure
 
 This repository uses the plugin format with a nested structure:
+
 ```
 playwright-skill/              # Plugin root
 ├── .claude-plugin/           # Plugin metadata
@@ -61,6 +62,7 @@ Verify installation by running `/help` to confirm the skill is available.
 To install as a standalone skill (without the plugin system), extract only the skill folder:
 
 **Global Installation (Available Everywhere):**
+
 ```bash
 # Clone to a temporary location
 git clone https://github.com/lackeyjb/playwright-skill.git /tmp/playwright-skill-temp
@@ -78,6 +80,7 @@ rm -rf /tmp/playwright-skill-temp
 ```
 
 **Project-Specific Installation:**
+
 ```bash
 # Clone to a temporary location
 git clone https://github.com/lackeyjb/playwright-skill.git /tmp/playwright-skill-temp
@@ -123,6 +126,7 @@ After installation, simply ask Claude to test or automate any browser task. Clau
 ## Usage Examples
 
 ### Test Any Page
+
 ```
 "Test the homepage"
 "Check if the contact form works"
@@ -130,12 +134,14 @@ After installation, simply ask Claude to test or automate any browser task. Clau
 ```
 
 ### Visual Testing
+
 ```
 "Take screenshots of the dashboard in mobile and desktop"
 "Test responsive design across different viewports"
 ```
 
 ### Interaction Testing
+
 ```
 "Fill out the registration form and submit it"
 "Click through the main navigation"
@@ -143,6 +149,7 @@ After installation, simply ask Claude to test or automate any browser task. Clau
 ```
 
 ### Validation
+
 ```
 "Check for broken links"
 "Verify all images load"
@@ -160,6 +167,7 @@ After installation, simply ask Claude to test or automate any browser task. Clau
 ## Configuration
 
 Default settings:
+
 - **Headless:** `false` (browser visible unless explicitly requested otherwise)
 - **Slow Motion:** `100ms` for visibility
 - **Timeout:** `30s`
@@ -174,12 +182,12 @@ playwright-skill/
 │   └── marketplace.json     # Marketplace configuration
 ├── skills/
 │   └── playwright-skill/    # The actual skill (Claude discovers this)
-│       ├── SKILL.md         # What Claude reads (314 lines)
+│       ├── SKILL.md         # What Claude reads
 │       ├── run.js           # Universal executor (proper module resolution)
 │       ├── package.json     # Dependencies & setup scripts
 │       └── lib/
 │           └── helpers.js   # Optional utility functions
-├── API_REFERENCE.md         # Full Playwright API reference (630 lines)
+│       └── API_REFERENCE.md # Full Playwright API reference
 ├── README.md                # This file - user documentation
 ├── CONTRIBUTING.md          # Contribution guidelines
 └── LICENSE                  # MIT License
@@ -191,8 +199,8 @@ Claude will automatically load `API_REFERENCE.md` when needed for comprehensive 
 
 ## Dependencies
 
-- Node.js >= 14.0.0
-- Playwright ^1.48.0 (installed via `npm run setup`)
+- Node.js
+- Playwright (installed via `npm run setup`)
 - Chromium (installed via `npm run setup`)
 
 ## Troubleshooting
@@ -209,11 +217,11 @@ Verify `headless: false` is set. The skill defaults to visible browser unless he
 **Install all browsers?**
 Run `npm run install-all-browsers` from the skill directory.
 
-## What is a Claude Skill?
+## What is a Skill?
 
-[Skills](https://www.anthropic.com/news/skills) are modular capabilities that extend Claude's functionality. Unlike slash commands that you invoke manually, skills are model-invoked—Claude autonomously decides when to use them based on your request.
+[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that agents can discover and use to do things more accurately and efficiently. When you ask Claude to test a webpage or automate browser interactions, Claude discovers this skill, loads the necessary instructions, executes custom Playwright code, and returns results with screenshots and console output.
 
-When you ask Claude to test a webpage or automate browser interactions, Claude discovers this skill, loads the necessary instructions, executes custom Playwright code, and returns results with screenshots and console output.
+This Playwright skill implements the [open Agent Skills specification](https://agentskills.io), making it compatible across agent platforms.
 
 ## Contributing
 
@@ -221,11 +229,11 @@ Contributions are welcome. Fork the repository, create a feature branch, make yo
 
 ## Learn More
 
-- [Claude Skills](https://www.anthropic.com/news/skills) - Official announcement from Anthropic
+- [Agent Skills Specification](https://agentskills.io) - Open specification for agent skills
 - [Claude Code Skills Documentation](https://docs.claude.com/en/docs/claude-code/skills)
 - [Claude Code Plugins Documentation](https://docs.claude.com/en/docs/claude-code/plugins)
 - [Plugin Marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)
-- [API_REFERENCE.md](API_REFERENCE.md) - Full Playwright documentation
+- [API_REFERENCE.md](skills/playwright-skill/API_REFERENCE.md) - Full Playwright documentation
 - [GitHub Issues](https://github.com/lackeyjb/playwright-skill/issues)
 
 ## License

--- a/skills/playwright-skill/API_REFERENCE.md
+++ b/skills/playwright-skill/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Playwright Skill - Complete API Reference
 
-This document contains the comprehensive Playwright API reference and advanced patterns. For quick-start execution patterns, see [SKILL.md](skills/playwright-skill/SKILL.md).
+This document contains the comprehensive Playwright API reference and advanced patterns. For quick-start execution patterns, see [SKILL.md](SKILL.md).
 
 ## Table of Contents
 

--- a/skills/playwright-skill/SKILL.md
+++ b/skills/playwright-skill/SKILL.md
@@ -1,15 +1,13 @@
 ---
-name: Playwright Browser Automation
+name: playwright-skill
 description: Complete browser automation with Playwright. Auto-detects dev servers, writes clean test scripts to /tmp. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use when user wants to test websites, automate browser interactions, validate web functionality, or perform any browser-based testing.
-version: 4.0.0
-author: Claude Assistant
-tags: [testing, automation, browser, e2e, playwright, web-testing]
 ---
 
 **IMPORTANT - Path Resolution:**
 This skill can be installed in different locations (plugin system, manual installation, global, or project-specific). Before executing any commands, determine the skill directory based on where you loaded this SKILL.md file, and use that path in all commands below. Replace `$SKILL_DIR` with the actual discovered path.
 
 Common installation paths:
+
 - Plugin system: `~/.claude/plugins/marketplaces/playwright-skill/skills/playwright-skill`
 - Manual global: `~/.claude/skills/playwright-skill`
 - Project-specific: `<project>/.claude/skills/playwright-skill`
@@ -21,9 +19,11 @@ General-purpose browser automation skill. I'll write custom Playwright code for 
 **CRITICAL WORKFLOW - Follow these steps in order:**
 
 1. **Auto-detect dev servers** - For localhost testing, ALWAYS run server detection FIRST:
+
    ```bash
    cd $SKILL_DIR && node -e "require('./lib/helpers').detectDevServers().then(servers => console.log(JSON.stringify(servers)))"
    ```
+
    - If **1 server found**: Use it automatically, inform user
    - If **multiple servers found**: Ask user which one to test
    - If **no servers found**: Ask for URL or offer to help start dev server
@@ -217,12 +217,12 @@ const { chromium } = require('playwright');
   try {
     await page.goto('http://localhost:3000', {
       waitUntil: 'networkidle',
-      timeout: 10000
+      timeout: 10000,
     });
 
     await page.screenshot({
       path: '/tmp/screenshot.png',
-      fullPage: true
+      fullPage: true,
     });
 
     console.log('📸 Screenshot saved to /tmp/screenshot.png');
@@ -249,15 +249,17 @@ const TARGET_URL = 'http://localhost:3001'; // Auto-detected
   const viewports = [
     { name: 'Desktop', width: 1920, height: 1080 },
     { name: 'Tablet', width: 768, height: 1024 },
-    { name: 'Mobile', width: 375, height: 667 }
+    { name: 'Mobile', width: 375, height: 667 },
   ];
 
   for (const viewport of viewports) {
-    console.log(`Testing ${viewport.name} (${viewport.width}x${viewport.height})`);
+    console.log(
+      `Testing ${viewport.name} (${viewport.width}x${viewport.height})`,
+    );
 
     await page.setViewportSize({
       width: viewport.width,
-      height: viewport.height
+      height: viewport.height,
     });
 
     await page.goto(TARGET_URL);
@@ -265,7 +267,7 @@ const TARGET_URL = 'http://localhost:3001'; // Auto-detected
 
     await page.screenshot({
       path: `/tmp/${viewport.name.toLowerCase()}.png`,
-      fullPage: true
+      fullPage: true,
     });
   }
 
@@ -291,6 +293,7 @@ await browser.close();
 ```
 
 **When to use inline vs files:**
+
 - **Inline**: Quick one-off tasks (screenshot, check if element exists, get page title)
 - **Files**: Complex tests, responsive design checks, anything user might want to re-run
 
@@ -326,6 +329,7 @@ See `lib/helpers.js` for full list.
 ## Custom HTTP Headers
 
 Configure custom headers for all HTTP requests via environment variables. Useful for:
+
 - Identifying automated traffic to your backend
 - Getting LLM-optimized responses (e.g., plain text errors instead of styled HTML)
 - Adding authentication tokens globally
@@ -333,12 +337,14 @@ Configure custom headers for all HTTP requests via environment variables. Useful
 ### Configuration
 
 **Single header (common case):**
+
 ```bash
 PW_HEADER_NAME=X-Automated-By PW_HEADER_VALUE=playwright-skill \
   cd $SKILL_DIR && node run.js /tmp/my-script.js
 ```
 
 **Multiple headers (JSON format):**
+
 ```bash
 PW_EXTRA_HEADERS='{"X-Automated-By":"playwright-skill","X-Debug":"true"}' \
   cd $SKILL_DIR && node run.js /tmp/my-script.js
@@ -358,7 +364,7 @@ For scripts using raw Playwright API, use the injected `getContextOptionsWithHea
 
 ```javascript
 const context = await browser.newContext(
-  getContextOptionsWithHeaders({ viewport: { width: 1920, height: 1080 } })
+  getContextOptionsWithHeaders({ viewport: { width: 1920, height: 1080 } }),
 );
 ```
 
@@ -391,6 +397,7 @@ For comprehensive Playwright API documentation, see [API_REFERENCE.md](API_REFER
 ## Troubleshooting
 
 **Playwright not installed:**
+
 ```bash
 cd $SKILL_DIR && npm run setup
 ```


### PR DESCRIPTION
## Summary
- Move `API_REFERENCE.md` into skill directory so it's discoverable when linked from SKILL.md (fixes #19)
- Update SKILL.md frontmatter to align with [Agent Skills spec](https://agentskills.io)
- Update README links and references accordingly