### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Playwright Skill for Claude Code
 
+[![Run in Smithery](https://smithery.ai/badge/skills/lackeyjb)](https://smithery.ai/skills?ns=lackeyjb&utm_source=github&utm_medium=badge)
+
+
 **General-purpose browser automation as a Claude Skill**
 
 A [Claude Skill](https://www.anthropic.com/blog/skills) that enables Claude to write and execute any Playwright automation on-the-fly - from simple page tests to complex multi-step flows. Packaged as a [Claude Code Plugin](https://docs.claude.com/en/docs/claude-code/plugins) for easy installation and distribution.


### PR DESCRIPTION
## Add skill discoverability badge

Your 2 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/lackeyjb)](https://smithery.ai/skills?ns=lackeyjb&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.