### PR TITLE
feat: add user-configurable browser selection via .claude/playwright.local.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-skill",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Claude Code Skill for general-purpose browser automation with Playwright. Auto-detects dev servers, writes clean test scripts to /tmp, and autonomously handles any browser automation task.",
   "author": {
     "name": "lackeyjb"

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ screenshots/
 # Testing
 MANUAL_TEST.md
 TEST_PLAN.md
+.claude/playwright.local.md
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,5 @@ screenshots/
 # Testing
 MANUAL_TEST.md
 TEST_PLAN.md
-.claude/playwright.local.md
+.claude/playwright.local.json
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ After installation, simply ask Claude to test or automate any browser task. Clau
 
 ## Configuration
 
-Configure your preferred browser by creating `.claude/playwright.local.md` in your project.
+Configure your preferred browser by creating `.claude/playwright.local.json` in your project.
 
 ### Configuration Options
 
@@ -188,30 +188,30 @@ Configure your preferred browser by creating `.claude/playwright.local.md` in yo
 ### Example Configurations
 
 **Using Playwright's bundled Chromium (default):**
-```markdown
----
-browser: chromium
-headless: false
----
+```json
+{
+  "browser": "chromium",
+  "headless": false
+}
 ```
 
 **Using Chrome or Edge (via channel):**
-```markdown
----
-browser: chromium
-channel: chrome
-headless: false
----
+```json
+{
+  "browser": "chromium",
+  "channel": "chrome",
+  "headless": false
+}
 ```
 
 **Using Brave (via executablePath):**
-```markdown
----
-browser: chromium
-headless: false
-executablePath: /Applications/Brave Browser.app/Contents/MacOS/Brave Browser
-slowMo: 50
----
+```json
+{
+  "browser": "chromium",
+  "headless": false,
+  "executablePath": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+  "slowMo": 50
+}
 ```
 
 ### Browser Channels (Chromium)
@@ -235,12 +235,12 @@ Brave requires `executablePath` since it's not a standard Playwright channel:
 
 ### Using Firefox or WebKit
 
-```yaml
-browser: firefox
+```json
+{ "browser": "firefox" }
 ```
 
-```yaml
-browser: webkit
+```json
+{ "browser": "webkit" }
 ```
 
 Note: Firefox and WebKit require their respective Playwright browser installations:
@@ -282,7 +282,7 @@ Navigate to the skill directory and run `npm run setup`.
 Ensure automation runs via `run.js`, which handles module resolution.
 
 **Browser doesn't open?**
-Check `headless: false` in your `.claude/playwright.local.md` config.
+Check `headless: false` in your `.claude/playwright.local.json` config.
 
 **Browser executable not found?**
 Verify the `executablePath` in your config points to a valid browser installation.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,29 @@ Claude autonomously decides when to use this skill based on your browser automat
 
 Made using Claude Code.
 
+## What is a Skill?
+
+[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that agents can discover and use to do things more accurately and efficiently. When you ask Claude to test a webpage or automate browser interactions, Claude discovers this skill, loads the necessary instructions, executes custom Playwright code, and returns results with screenshots and console output.
+
+This Playwright skill implements the [open Agent Skills specification](https://agentskills.io), making it compatible across agent platforms.
+
 ## Features
 
 - **Any Automation Task** - Claude writes custom code for your specific request, not limited to pre-built scripts
+- **Configurable Browser** - Use Playwright's bundled Chromium, or your installed browser (Chrome, Edge, Brave, Firefox, WebKit)
 - **Visible Browser by Default** - See automation in real-time with `headless: false`
 - **Zero Module Resolution Errors** - Universal executor ensures proper module access
 - **Progressive Disclosure** - Concise SKILL.md with full API reference loaded only when needed
 - **Safe Cleanup** - Smart temp file management without race conditions
 - **Comprehensive Helpers** - Optional utility functions for common tasks
+
+## How It Works
+
+1. Describe what you want to test or automate
+2. Claude writes custom Playwright code for the task
+3. The universal executor (run.js) runs it with proper module resolution
+4. Browser opens (visible by default) and automation executes
+5. Results are displayed with console output and screenshots
 
 ## Installation
 
@@ -156,22 +171,83 @@ After installation, simply ask Claude to test or automate any browser task. Clau
 "Test form validation"
 ```
 
-## How It Works
-
-1. Describe what you want to test or automate
-2. Claude writes custom Playwright code for the task
-3. The universal executor (run.js) runs it with proper module resolution
-4. Browser opens (visible by default) and automation executes
-5. Results are displayed with console output and screenshots
-
 ## Configuration
 
-Default settings:
+Configure your preferred browser by creating `.claude/playwright.local.md` in your project.
 
-- **Headless:** `false` (browser visible unless explicitly requested otherwise)
-- **Slow Motion:** `100ms` for visibility
-- **Timeout:** `30s`
-- **Screenshots:** Saved to `/tmp/`
+### Configuration Options
+
+| Option | Values | Description | Default |
+|--------|--------|-------------|---------|
+| `browser` | `chromium`, `firefox`, `webkit` | Browser engine | `chromium` |
+| `channel` | `chrome`, `msedge`, etc. | Use installed Chrome/Edge | none |
+| `headless` | `true`, `false` | Run without visible window | `false` |
+| `executablePath` | Path string | Custom browser executable | none |
+| `slowMo` | Number (ms) | Slow down operations | `0` |
+
+### Example Configurations
+
+**Using Playwright's bundled Chromium (default):**
+```markdown
+---
+browser: chromium
+headless: false
+---
+```
+
+**Using Chrome or Edge (via channel):**
+```markdown
+---
+browser: chromium
+channel: chrome
+headless: false
+---
+```
+
+**Using Brave (via executablePath):**
+```markdown
+---
+browser: chromium
+headless: false
+executablePath: /Applications/Brave Browser.app/Contents/MacOS/Brave Browser
+slowMo: 50
+---
+```
+
+### Browser Channels (Chromium)
+
+Instead of downloading Playwright's bundled Chromium, use your installed browser:
+
+- `chrome` - Google Chrome
+- `msedge` - Microsoft Edge
+- `chrome-beta`, `chrome-dev`, `chrome-canary` - Chrome pre-release
+- `msedge-beta`, `msedge-dev` - Edge pre-release
+
+### Using Brave Browser
+
+Brave requires `executablePath` since it's not a standard Playwright channel:
+
+| Platform | Path |
+|----------|------|
+| macOS | `/Applications/Brave Browser.app/Contents/MacOS/Brave Browser` |
+| Linux | `/usr/bin/brave-browser` |
+| Windows | `C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe` |
+
+### Using Firefox or WebKit
+
+```yaml
+browser: firefox
+```
+
+```yaml
+browser: webkit
+```
+
+Note: Firefox and WebKit require their respective Playwright browser installations:
+```bash
+cd ~/.claude/skills/playwright-skill  # or your install path
+npm run install-all-browsers
+```
 
 ## Project Structure
 
@@ -185,8 +261,8 @@ playwright-skill/
 │       ├── SKILL.md         # What Claude reads
 │       ├── run.js           # Universal executor (proper module resolution)
 │       ├── package.json     # Dependencies & setup scripts
-│       └── lib/
-│           └── helpers.js   # Optional utility functions
+│       ├── lib/
+│       │   └── helpers.js   # Optional utility functions
 │       └── API_REFERENCE.md # Full Playwright API reference
 ├── README.md                # This file - user documentation
 ├── CONTRIBUTING.md          # Contribution guidelines
@@ -197,12 +273,6 @@ playwright-skill/
 
 Claude will automatically load `API_REFERENCE.md` when needed for comprehensive documentation on selectors, network interception, authentication, visual regression testing, mobile emulation, performance testing, and debugging.
 
-## Dependencies
-
-- Node.js
-- Playwright (installed via `npm run setup`)
-- Chromium (installed via `npm run setup`)
-
 ## Troubleshooting
 
 **Playwright not installed?**
@@ -212,16 +282,19 @@ Navigate to the skill directory and run `npm run setup`.
 Ensure automation runs via `run.js`, which handles module resolution.
 
 **Browser doesn't open?**
-Verify `headless: false` is set. The skill defaults to visible browser unless headless mode is requested.
+Check `headless: false` in your `.claude/playwright.local.md` config.
+
+**Browser executable not found?**
+Verify the `executablePath` in your config points to a valid browser installation.
 
 **Install all browsers?**
 Run `npm run install-all-browsers` from the skill directory.
 
-## What is a Skill?
+## Dependencies
 
-[Agent Skills](https://agentskills.io) are folders of instructions, scripts, and resources that agents can discover and use to do things more accurately and efficiently. When you ask Claude to test a webpage or automate browser interactions, Claude discovers this skill, loads the necessary instructions, executes custom Playwright code, and returns results with screenshots and console output.
-
-This Playwright skill implements the [open Agent Skills specification](https://agentskills.io), making it compatible across agent platforms.
+- **Node.js** >= 14.0.0
+- **Playwright** (installed via `npm run setup`)
+- **Browser** - Chromium bundled by default, or configure your preferred browser
 
 ## Contributing
 

--- a/skills/playwright-skill/SKILL.md
+++ b/skills/playwright-skill/SKILL.md
@@ -50,25 +50,25 @@ General-purpose browser automation skill. I'll write custom Playwright code for 
 
 ## Browser Configuration
 
-Users can configure their preferred browser by creating `.claude/playwright.local.md` in their project:
+Users can configure their preferred browser by creating `.claude/playwright.local.json` in their project:
 
-```markdown
----
-browser: chromium
-headless: false
-executablePath: /Applications/Brave Browser.app/Contents/MacOS/Brave Browser
-slowMo: 50
----
+```json
+{
+  "browser": "chromium",
+  "headless": false,
+  "executablePath": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+  "slowMo": 50
+}
 ```
 
 Or use a standard Playwright channel like Chrome or Edge:
 
-```markdown
----
-browser: chromium
-channel: chrome
-headless: false
----
+```json
+{
+  "browser": "chromium",
+  "channel": "chrome",
+  "headless": false
+}
 ```
 
 **Configuration options:**
@@ -88,11 +88,11 @@ headless: false
 - `msedge-beta`, `msedge-dev` - Edge pre-release
 
 **For Brave Browser:** Use `executablePath` since Brave isn't a standard Playwright channel:
-```yaml
-executablePath: /Applications/Brave Browser.app/Contents/MacOS/Brave Browser
+```json
+{ "executablePath": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" }
 ```
 
-**IMPORTANT:** When a config file exists, scripts should use `launchConfiguredBrowser()` instead of `chromium.launch()` to respect user preferences.
+**IMPORTANT:** When a config file exists, scripts should use `launchConfiguredBrowser()` instead of `chromium.launch()` to respect user preferences from `.claude/playwright.local.json`.
 
 ## Setup (First Time)
 
@@ -118,7 +118,7 @@ cd $SKILL_DIR && node -e "require('./lib/helpers').detectDevServers().then(s => 
 // Parameterized URL (detected or user-provided)
 const TARGET_URL = 'http://localhost:3001'; // <-- Auto-detected or from user
 
-// launchConfiguredBrowser() reads from .claude/playwright.local.md
+// launchConfiguredBrowser() reads from .claude/playwright.local.json
 const browser = await launchConfiguredBrowser();
 const page = await browser.newPage();
 
@@ -131,7 +131,7 @@ console.log('📸 Screenshot saved to /tmp/screenshot.png');
 await browser.close();
 ```
 
-**Note:** Scripts without `require()` are auto-wrapped with helpers. Use `launchConfiguredBrowser()` to respect user's browser preferences from `.claude/playwright.local.md`.
+**Note:** Scripts without `require()` are auto-wrapped with helpers. Use `launchConfiguredBrowser()` to respect user's browser preferences from `.claude/playwright.local.json`.
 
 **Step 3: Execute from skill directory**
 
@@ -311,7 +311,7 @@ await browser.close();
 For quick one-off tasks, you can execute code inline without creating files:
 
 ```bash
-# Take a quick screenshot (uses browser from .claude/playwright.local.md)
+# Take a quick screenshot (uses browser from .claude/playwright.local.json)
 cd $SKILL_DIR && node run.js "
 const browser = await launchConfiguredBrowser();
 const page = await browser.newPage();
@@ -334,11 +334,11 @@ Optional utility functions in `lib/helpers.js`:
 ```javascript
 const helpers = require('./lib/helpers');
 
-// Read browser config from .claude/playwright.local.md
+// Read browser config from .claude/playwright.local.json
 const config = helpers.readBrowserConfig();
 console.log('Browser config:', config);
 
-// Launch browser with config (auto-reads .claude/playwright.local.md)
+// Launch browser with config (auto-reads .claude/playwright.local.json)
 const browser = await helpers.launchBrowser();
 // Or specify options: helpers.launchBrowser('chromium', { channel: 'brave' })
 
@@ -427,7 +427,7 @@ For comprehensive Playwright API documentation, see [API_REFERENCE.md](API_REFER
 ## Tips
 
 - **CRITICAL: Detect servers FIRST** - Always run `detectDevServers()` before writing test code for localhost testing
-- **Respect user's browser config** - Always use `launchConfiguredBrowser()` to honor `.claude/playwright.local.md` settings
+- **Respect user's browser config** - Always use `launchConfiguredBrowser()` to honor `.claude/playwright.local.json` settings
 - **Custom headers** - Use `PW_HEADER_NAME`/`PW_HEADER_VALUE` env vars to identify automated traffic to your backend
 - **Use /tmp for test files** - Write to `/tmp/playwright-test-*.js`, never to skill directory or user's project
 - **Parameterize URLs** - Put detected/provided URL in a `TARGET_URL` constant at the top of every script
@@ -449,16 +449,16 @@ cd $SKILL_DIR && npm run setup
 Ensure running from skill directory via `run.js` wrapper
 
 **Browser doesn't open:**
-Check `headless: false` in `.claude/playwright.local.md` and ensure display available
+Check `"headless": false` in `.claude/playwright.local.json` and ensure display available
 
 **Browser executable not found:**
-Verify the `executablePath` in `.claude/playwright.local.md` points to a valid browser:
+Verify the `executablePath` in `.claude/playwright.local.json` points to a valid browser:
 - macOS Brave: `/Applications/Brave Browser.app/Contents/MacOS/Brave Browser`
 - Linux Brave: `/usr/bin/brave-browser`
 - Windows Brave: `C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe`
 
 **Config not being read:**
-Config file must be at `.claude/playwright.local.md` in your project (searches upward from cwd)
+Config file must be at `.claude/playwright.local.json` in your project (searches upward from cwd)
 
 **Element not found:**
 Add wait: `await page.waitForSelector('.element', { timeout: 10000 })`

--- a/skills/playwright-skill/package.json
+++ b/skills/playwright-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-skill",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "General-purpose browser automation with Playwright for Claude Code with auto-detection and smart test management",
   "author": "lackeyjb",
   "main": "run.js",

--- a/skills/playwright-skill/run.js
+++ b/skills/playwright-skill/run.js
@@ -148,14 +148,14 @@ function wrapCodeIfNeeded(code) {
 const { chromium, firefox, webkit, devices } = require('playwright');
 const helpers = require('./lib/helpers');
 
-// Browser configuration from .claude/playwright.local.md (if exists)
+// Browser configuration from .claude/playwright.local.json (if exists)
 const __browserConfig = helpers.readBrowserConfig();
 
 // Extra headers from environment variables (if configured)
 const __extraHeaders = helpers.getExtraHeadersFromEnv();
 
 /**
- * Get browser configuration from .claude/playwright.local.md
+ * Get browser configuration from .claude/playwright.local.json
  * Returns: { browser, channel, headless, executablePath, slowMo }
  */
 function getBrowserConfig() {
@@ -163,7 +163,7 @@ function getBrowserConfig() {
 }
 
 /**
- * Launch browser using configuration from .claude/playwright.local.md
+ * Launch browser using configuration from .claude/playwright.local.json
  * Automatically uses configured browser type, channel, and executable path.
  * @param {Object} options - Additional options to override config
  */


### PR DESCRIPTION
This release adds support for configuring the browser used by the playwright-skill through a per-project configuration file, eliminating the hard dependency on Chrome and allowing users to use their preferred browser.

## Problem

The skill previously hardcoded Chrome as the browser, requiring users to have Chrome installed. Users with alternative browsers (Brave, Edge, Firefox) or those preferring Playwright's bundled browsers had no configuration option. The skill also didn't respect any local configuration files.

## Solution

Added `.claude/playwright.local.md` configuration file support with YAML frontmatter for browser settings:

```yaml
---
browser: chromium | firefox | webkit
channel: chrome | msedge | chrome-beta | msedge-beta
headless: true | false
executablePath: /path/to/browser
slowMo: 100
---
```

## Changes

### lib/helpers.js (+206 lines)
- Added `readBrowserConfig()` - reads config from .claude/playwright.local.md
- Added `findConfigFile()` - searches upward from cwd to find config
- Added `parseYamlFrontmatter()` - simple YAML parser for frontmatter
- Updated `launchBrowser()` to use config and support `channel`/`executablePath`

### run.js (+74 lines)
- Added `launchConfiguredBrowser()` - auto-injected function for scripts
- Added `getBrowserConfig()` - exposes config to scripts
- Updated `installPlaywright()` to skip browser download if executablePath set
- Config-aware browser installation based on user preferences

### SKILL.md (+338/-184 lines)
- Added "Browser Configuration" section with full documentation
- Updated all code examples to use `launchConfiguredBrowser()` instead of hardcoded `chromium.launch()`
- Added troubleshooting for browser config issues
- Added optional frontmatter fields per Agent Skills spec:
  - license: MIT
  - compatibility: Requires Node.js
  - metadata: author, version

### README.md (+98/-25 lines)
- Restructured for better flow (moved "What is a Skill?" earlier)
- Added comprehensive "Configuration" section with examples
- Added Brave browser paths for macOS/Linux/Windows
- Merged "Default Settings" into Configuration table
- Added "Configurable Browser" to Features list
- Updated Dependencies with Node.js version requirement

### Version bump to 4.2.0
- .claude-plugin/plugin.json
- skills/playwright-skill/package.json
- skills/playwright-skill/SKILL.md (metadata.version)

## Testing

Verified with:
- Playwright's bundled Chromium (headless)
- Brave Browser via executablePath (headless)
- Config file discovery from nested directories

## Breaking Changes

None. Existing scripts using `chromium.launch()` continue to work. New `launchConfiguredBrowser()` is additive and recommended for new scripts.