### PR TITLE
feat: add unit tests

### DIFF
--- a/skills/playwright-skill/test.aptitude.yml
+++ b/skills/playwright-skill/test.aptitude.yml
@@ -1,0 +1,17 @@
+name: "Playwright"
+prompt: "/playwright-skill automate a task by going to 'https://github.com/microsoft/playwright' and getting the current semantic version of Playwright"
+assertions:
+
+  # Should use playwright-skill, not web search
+  - tool: WebSearch
+    called: false
+
+  # Writes a script to /tmp/
+  - tool: Write
+    params:
+      file_path: "/tmp/.*"
+
+  # Runs the playwright skill with node run.js
+  - tool: Bash
+    params:
+      command: ".*\\.claude/skills/playwright-skill && node run\\.js.*"


### PR DESCRIPTION
I wanted to share a [test harness for claude-code](https://github.com/tatimblin/aptitude) you can use it to assert on claude-code behavior from markdown content. For example assert that files are written to `/tmp/*`. The harness has to be installed separately
```
brew tap tatimblin/aptitude
brew install aptitude
```
and then you can use `aptitude run .` on your project.

If this is not something you're interested in feel free to disregard.