### PR TITLE
docs: use locator-first examples in the API reference

### DIFF
--- a/skills/playwright-skill/API_REFERENCE.md
+++ b/skills/playwright-skill/API_REFERENCE.md
@@ -187,9 +187,12 @@ await row.locator('button.edit').click();
 await page.getByLabel('Email').fill('user@example.com');
 await page.getByPlaceholder('Enter your name').fill('John Doe');
 
-// Clear and type
+// Clear and refill
 await page.locator('#username').clear();
-await page.locator('#username').type('newuser', { delay: 100 });
+await page.locator('#username').fill('newuser');
+
+// Only when the page has special per-key handling (autocomplete, masking)
+await page.locator('#username').pressSequentially('newuser', { delay: 100 });
 
 // Checkbox
 await page.getByLabel('I agree').check();
@@ -199,16 +202,16 @@ await page.getByLabel('Subscribe').uncheck();
 await page.getByLabel('Option 2').check();
 
 // Select dropdown
-await page.selectOption('select#country', 'usa');
-await page.selectOption('select#country', { label: 'United States' });
-await page.selectOption('select#country', { index: 2 });
+await page.locator('select#country').selectOption('usa');
+await page.locator('select#country').selectOption({ label: 'United States' });
+await page.locator('select#country').selectOption({ index: 2 });
 
 // Multi-select
-await page.selectOption('select#colors', ['red', 'blue', 'green']);
+await page.locator('select#colors').selectOption(['red', 'blue', 'green']);
 
 // File upload
-await page.setInputFiles('input[type="file"]', 'path/to/file.pdf');
-await page.setInputFiles('input[type="file"]', [
+await page.locator('input[type="file"]').setInputFiles('path/to/file.pdf');
+await page.locator('input[type="file"]').setInputFiles([
   'file1.pdf',
   'file2.pdf'
 ]);
@@ -218,13 +221,13 @@ await page.setInputFiles('input[type="file"]', [
 
 ```javascript
 // Click variations
-await page.click('button');                          // Left click
-await page.click('button', { button: 'right' });    // Right click
-await page.dblclick('button');                       // Double click
-await page.click('button', { position: { x: 10, y: 10 } });  // Click at position
+await page.getByRole('button').click();                          // Left click
+await page.getByRole('button').click({ button: 'right' });       // Right click
+await page.getByRole('button').dblclick();                       // Double click
+await page.getByRole('button').click({ position: { x: 10, y: 10 } });  // Click at position
 
 // Hover
-await page.hover('.menu-item');
+await page.locator('.menu-item').hover();
 
 // Drag and drop
 await page.dragAndDrop('#source', '#target');
@@ -282,7 +285,7 @@ await page.waitForFunction(
 
 // Wait for response
 const responsePromise = page.waitForResponse('**/api/users');
-await page.click('button#load-users');
+await page.locator('button#load-users').click();
 const response = await responsePromise;
 
 // Wait for request
@@ -527,9 +530,9 @@ const testData = [
 testData.forEach(({ username, password, expected }) => {
   test(`login with ${username}`, async ({ page }) => {
     await page.goto('/login');
-    await page.fill('#username', username);
-    await page.fill('#password', password);
-    await page.click('button[type="submit"]');
+    await page.locator('#username').fill(username);
+    await page.locator('#password').fill(password);
+    await page.getByRole('button', { name: 'Submit' }).click();
     await expect(page.locator('.message')).toHaveText(expected);
   });
 });
@@ -585,7 +588,7 @@ jobs:
 ```javascript
 const [popup] = await Promise.all([
   page.waitForEvent('popup'),
-  page.click('button.open-popup')
+  page.locator('button.open-popup').click()
 ]);
 await popup.waitForLoadState();
 ```
@@ -595,7 +598,7 @@ await popup.waitForLoadState();
 ```javascript
 const [download] = await Promise.all([
   page.waitForEvent('download'),
-  page.click('button.download')
+  page.locator('button.download').click()
 ]);
 await download.saveAs(`./downloads/${download.suggestedFilename()}`);
 ```


### PR DESCRIPTION
Closes #46.

I checked every candidate against Playwright's own doc source (`microsoft/playwright`, `docs/src/api/*.md`) rather than going from memory, since the issue asks to replace only where current guidance clearly prefers something better. Three groups came out of it.

**Deprecated, replaced.** `locator.type` carries a deprecation note verbatim:

> `* deprecated: In most cases, you should use [method: Locator.fill] instead. You only need to press keys one by one if there is special keyboard handling on the page - in this case use [method: Locator.pressSequentially].`

The "clear and type" example now shows `fill` for the ordinary case and `pressSequentially` for the per-key one, labelled so a reader knows which situation each is for, rather than silently swapping one for the other.

**Discouraged, replaced.** Six page-level selector APIs in the reference carry a `discouraged` marker pointing at their locator equivalent:

| API | note in `class-page.md` |
| --- | --- |
| `page.click` | Use locator-based `Locator.click` instead |
| `page.fill` | Use locator-based `Locator.fill` instead |
| `page.selectOption` | Use locator-based `Locator.selectOption` instead |
| `page.setInputFiles` | Use locator-based `Locator.setInputFiles` instead |
| `page.hover` | Use locator-based `Locator.hover` instead |
| `page.dblclick` | Use locator-based `Locator.dblclick` instead |

Those cover the form, mouse, network-wait, data-driven, popup and download examples. Where the element was described by role in prose I used `getByRole` rather than mechanically wrapping the CSS selector in `page.locator(...)`, since the reference already teaches role-first locators a few sections earlier; where the example was pinned to a specific id or class I kept that selector and just moved it into a locator.

**Not touched, on purpose.** `page.keyboard.type` stays. It has no deprecation or discouraged note, and `class-keyboard.md` still calls it "the high level api" and uses it in its own example. Replacing it would have been the audit overreaching. I also found no `waitForTimeout` and no `networkidle` anywhere in the file, so nothing to do on the two patterns the issue names first.

**What I ran**, on Windows with Node 22.20.0:

- `npm test` in `skills/playwright-skill`: 12 pass, 0 fail
- `npx skills-ref@0.1.5 validate .` in the same directory, which is what CI runs: `Valid skill: .`
- a grep afterwards for the whole discouraged set to confirm none survived in the file

Docs-only change, 22 lines added and 19 removed, no behaviour anywhere.
